### PR TITLE
render file name on files page and message page

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -2,7 +2,7 @@ import { Segment } from 'health-level-seven-parser'
 
 export interface HL7File {
   id: string
-  name: string
+  filename: string
 }
 
 export interface HL7Message {

--- a/src/views/FilesPage.tsx
+++ b/src/views/FilesPage.tsx
@@ -44,7 +44,7 @@ const FilesPageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }> =
             <Card>
               <CardContent>
                 <Typography>
-                  {f.name}
+                  {f.filename}
                 </Typography>
               </CardContent>
               <CardActions>

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -93,7 +93,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
   }, [getMessage, fileId, messageIndex])
 
   const file = files.find((f) => f.id === fileId);
-  const fileName = file ? file.name : 'Unknown File Name';
+  const fileName = file ? file.filename : 'Unknown File Name';
   const message = currentMessage;
   return message ? (
     <div className={classes.container}>


### PR DESCRIPTION
This fixes the bug that prevented the file name from rendering on the files list page. It also allows the file name to render on the message page before a refresh