### PR TITLE
fix file name after refresh

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -12,7 +12,7 @@ const api = axios.create({
 api.interceptors.response.use(function (response) {
   return response;
 }, function (error) {
-  if (error.response.status == 401) {
+  if (error.response.status === 401) {
     stores[USER_STORE].logout()
     alert("Oops! Your session has expired. Please sign in to continue");
   }

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -42,6 +42,10 @@ export const telescoperApi = {
     const response = await this.api.get('/api/hl7/files')
     return response.data
   },
+  async getFile(fileId: string): Promise<HL7File> {
+    const response = await this.api.get(`/api/hl7/files/${fileId}`)
+    return response.data
+  },
   async uploadFile(file: File): Promise<void> {
     const data = new FormData()
     data.append('hl7-file', file)

--- a/src/stores/fileStore.ts
+++ b/src/stores/fileStore.ts
@@ -10,7 +10,7 @@ export interface IFileStore {
   setCurrentMessage(msg: HL7Message): void;
   getFiles(): Promise<void>;
   getFile(fileId: string): Promise<void>;
-  setCurrentFile(file: HL7File): void;
+  setCurrentFile(file?: HL7File): void;
   getMessage(fileId: string, messageIndexWithinFile: number): Promise<void>;
 }
 
@@ -25,7 +25,7 @@ export class FileStore implements IFileStore {
   }
 
   @action.bound
-  setCurrentFile(file: HL7File) {
+  setCurrentFile(file?: HL7File) {
     this.currentFile = file
   }
   @action.bound
@@ -54,7 +54,7 @@ export class FileStore implements IFileStore {
     if (file) {
       this.setCurrentFile(file)
     } else {
-      this.setCurrentFile({id: '', filename: ''})
+      this.setCurrentFile(undefined)
     }
   }
 }

--- a/src/stores/fileStore.ts
+++ b/src/stores/fileStore.ts
@@ -5,19 +5,28 @@ import { HL7File, HL7Message } from '../types';
 export interface IFileStore {
   files: HL7File[];
   currentMessage?: HL7Message;
+  file?: HL7File;
   setFiles(files: HL7File[]): void;
   setCurrentMessage(msg: HL7Message): void;
   getFiles(): Promise<void>;
+  getFile(fileId: string): Promise<void>;
+  setFile(file: HL7File): void;
   getMessage(fileId: string, messageIndexWithinFile: number): Promise<void>;
 }
 
 export class FileStore implements IFileStore {
   @observable files: HL7File[] = []
   @observable currentMessage?: HL7Message
+  @observable file?: HL7File
 
   @action.bound
   setFiles(files: HL7File[]) {
     this.files = files
+  }
+
+  @action.bound
+  setFile(file: HL7File) {
+    this.file = file
   }
   @action.bound
   setCurrentMessage(msg: HL7Message) {
@@ -37,6 +46,16 @@ export class FileStore implements IFileStore {
   async getMessage(fileId: string, messageIndexWithinFile: number) {
     const msg = await telescoperApi.getMessage(fileId, messageIndexWithinFile)
     this.setCurrentMessage(msg)
+  }
+
+  @action.bound
+  async getFile(fileId: string) {
+    const file = await telescoperApi.getFile(fileId)
+    if (file) {
+      this.setFile(file)
+    } else {
+      this.setFile({id: '', filename: ''})
+    }
   }
 }
 

--- a/src/stores/fileStore.ts
+++ b/src/stores/fileStore.ts
@@ -5,19 +5,19 @@ import { HL7File, HL7Message } from '../types';
 export interface IFileStore {
   files: HL7File[];
   currentMessage?: HL7Message;
-  file?: HL7File;
+  currentFile?: HL7File;
   setFiles(files: HL7File[]): void;
   setCurrentMessage(msg: HL7Message): void;
   getFiles(): Promise<void>;
   getFile(fileId: string): Promise<void>;
-  setFile(file: HL7File): void;
+  setCurrentFile(file: HL7File): void;
   getMessage(fileId: string, messageIndexWithinFile: number): Promise<void>;
 }
 
 export class FileStore implements IFileStore {
   @observable files: HL7File[] = []
   @observable currentMessage?: HL7Message
-  @observable file?: HL7File
+  @observable currentFile?: HL7File
 
   @action.bound
   setFiles(files: HL7File[]) {
@@ -25,8 +25,8 @@ export class FileStore implements IFileStore {
   }
 
   @action.bound
-  setFile(file: HL7File) {
-    this.file = file
+  setCurrentFile(file: HL7File) {
+    this.currentFile = file
   }
   @action.bound
   setCurrentMessage(msg: HL7Message) {
@@ -52,9 +52,9 @@ export class FileStore implements IFileStore {
   async getFile(fileId: string) {
     const file = await telescoperApi.getFile(fileId)
     if (file) {
-      this.setFile(file)
+      this.setCurrentFile(file)
     } else {
-      this.setFile({id: '', filename: ''})
+      this.setCurrentFile({id: '', filename: ''})
     }
   }
 }

--- a/src/views/FileUploadPage.tsx
+++ b/src/views/FileUploadPage.tsx
@@ -1,8 +1,7 @@
 import React, { useState, ChangeEvent } from 'react';
 import { RouteComponentProps } from 'react-router';
 
-import { Container, Paper, Typography, makeStyles, Grid, TextField, Button } from '@material-ui/core';
-import { observer, inject } from 'mobx-react';
+import { Container, Paper, Typography, makeStyles, Grid, Button } from '@material-ui/core';
 import { telescoperApi } from '../services/api';
 
 const useStyles = makeStyles(theme => ({

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -82,7 +82,6 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-let currentFile;
 const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }> = (props) => {
   const { history, match: { params }, fileStore: { files, getMessage, currentMessage, getFile, file } } = props
   const { messageIndex, fileId } = params as any

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -88,16 +88,13 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
 
   const classes = useStyles();
   const [[selectedSegmentIndex, selectedFieldIndex], setSelected] = useState([-1, -1]);
-  const [filename, setFileName] = useState('')
+  
   useEffect(() => {
     getMessage(fileId, parseInt(messageIndex))
     getFile(fileId)
   }, [getMessage, fileId, messageIndex])
 
-  if (file && file.filename !== filename) {
-    setFileName(file.filename)
-  }
-
+  const filename = (file && file.filename) ? file.filename.split('/').pop() : 'Unknown File'
   const message = currentMessage;
   return message ? (
     <div className={classes.container}>
@@ -105,7 +102,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
         variant="h4"
         className={classes.title}
       >
-        {filename.split('/').pop()}
+        {filename}
       </Typography>
       <TextField
         className={classes.filter}

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -83,18 +83,18 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }> = (props) => {
-  const { history, match: { params }, fileStore: { files, getMessage, currentMessage, getFile, file } } = props
+  const { history, match: { params }, fileStore: { files, getMessage, currentMessage, getFile, currentFile } } = props
   const { messageIndex, fileId } = params as any
 
   const classes = useStyles();
   const [[selectedSegmentIndex, selectedFieldIndex], setSelected] = useState([-1, -1]);
-  
+
   useEffect(() => {
     getMessage(fileId, parseInt(messageIndex))
     getFile(fileId)
   }, [getMessage, fileId, messageIndex])
 
-  const filename = (file && file.filename) ? file.filename.split('/').pop() : 'Unknown File'
+  const filename = (currentFile && currentFile.filename) ? currentFile.filename.split('/').pop() : 'Unknown File'
   const message = currentMessage;
   return message ? (
     <div className={classes.container}>

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -83,7 +83,7 @@ const useStyles = makeStyles(theme => ({
 }));
 
 const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }> = (props) => {
-  const { history, match: { params }, fileStore: { files, getMessage, currentMessage, getFile, currentFile } } = props
+  const { history, match: { params }, fileStore: { getMessage, currentMessage, getFile, currentFile } } = props
   const { messageIndex, fileId } = params as any
 
   const classes = useStyles();
@@ -92,9 +92,9 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
   useEffect(() => {
     getMessage(fileId, parseInt(messageIndex))
     getFile(fileId)
-  }, [getMessage, fileId, messageIndex])
+  }, [getFile, getMessage, fileId, messageIndex])
 
-  const filename = (currentFile && currentFile.filename) ? currentFile.filename.split('/').pop() : 'Unknown File'
+  const filename = (currentFile && currentFile.filename) || 'Unknown File'
   const message = currentMessage;
   return message ? (
     <div className={classes.container}>

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -82,18 +82,23 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+let currentFile;
 const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }> = (props) => {
-  const { history, match: { params }, fileStore: { files, getMessage, currentMessage } } = props
+  const { history, match: { params }, fileStore: { files, getMessage, currentMessage, getFile, file } } = props
   const { messageIndex, fileId } = params as any
 
   const classes = useStyles();
   const [[selectedSegmentIndex, selectedFieldIndex], setSelected] = useState([-1, -1]);
+  const [filename, setFileName] = useState('')
   useEffect(() => {
     getMessage(fileId, parseInt(messageIndex))
+    getFile(fileId)
   }, [getMessage, fileId, messageIndex])
 
-  const file = files.find((f) => f.id === fileId);
-  const fileName = file ? file.filename : 'Unknown File Name';
+  if (file && file.filename !== filename) {
+    setFileName(file.filename)
+  }
+
   const message = currentMessage;
   return message ? (
     <div className={classes.container}>
@@ -101,7 +106,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
         variant="h4"
         className={classes.title}
       >
-        {fileName}
+        {filename.split('/').pop()}
       </Typography>
       <TextField
         className={classes.filter}


### PR DESCRIPTION
### Related JIRA tickets:
https://jira.amida.com/browse/HL7-37

### What exactly does this PR do?
When a user refreshed a page after navigating to a file page from the file list page, the file name at the top of the screen was lost. This PR allows us to retrieve the file from the back end when the page is loaded

### What else was added outside of the scope of the ask?
Nothing
### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
Not to my knowledge
### Manual test cases?
Simply navigate to a file detail page from the file list. Refresh the page and assert that the file name is rendered at the top of the screen


