### PR TITLE
expand subfields

### DIFF
--- a/src/components/ExpandableListItem.tsx
+++ b/src/components/ExpandableListItem.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import {ListItem, ListItemText, ListItemIcon, Collapse, List} from '@material-ui/core';
+import { ExpandMore, ExpandLess } from '@material-ui/icons';
+
+import { Field } from 'health-level-seven-parser'
+
+const ExpandableListItem: React.FC<{
+  field: Field;
+  expandableKey: string;
+  expandableClassName: string;
+  expandableOnClick: () => void;
+  nestedClassName: string
+}> = (props) => {
+
+  const [open, setOpen] = React.useState(false);
+
+  const {
+    field,
+    expandableKey,
+    expandableClassName,
+    expandableOnClick,
+    nestedClassName
+  } = props;
+
+  function handleClick() {
+    setOpen(!open);
+  }
+
+  return <div>
+    <ListItem button
+      key={expandableKey}
+      className={expandableClassName}
+      onClick={() => {
+        expandableOnClick();
+        handleClick();
+      }}
+    >
+      <ListItemText
+        primary={field.value ? field.value : '(empty)'}
+        secondary={field.definition && field.definition.description ? field.definition.description : field.name}
+      />
+      {open ? <ListItemIcon><ExpandLess/></ListItemIcon> : <ListItemIcon><ExpandMore/></ListItemIcon>}
+    </ListItem>
+    <Collapse in={open} timeout="auto" unmountOnExit>
+      <List component="div" disablePadding>
+        {(field.children as any[]).map((subfield, subfieldIndex) => !subfield ? undefined : (
+          <div><ListItem button
+             key={`${expandableKey}-${subfieldIndex}`}
+             className={nestedClassName}
+          >
+            <ListItemText
+              primary={subfield.value ? subfield.value : '(empty)'}
+              secondary={subfield.definition && subfield.definition.description ? subfield.definition.description : subfield.name}
+            />
+          </ListItem></div>
+        ))}
+      </List>
+    </Collapse>
+  </div>;
+
+}
+
+export default ExpandableListItem

--- a/src/components/ExpandableListItem.tsx
+++ b/src/components/ExpandableListItem.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import {ListItem, ListItemText, ListItemIcon, Collapse, List} from '@material-ui/core';
 import { ExpandMore, ExpandLess } from '@material-ui/icons';
@@ -13,7 +13,7 @@ const ExpandableListItem: React.FC<{
   nestedClassName: string
 }> = (props) => {
 
-  const [open, setOpen] = React.useState(false);
+  const [open, setOpen] = useState(false);
 
   const {
     field,
@@ -23,17 +23,13 @@ const ExpandableListItem: React.FC<{
     nestedClassName
   } = props;
 
-  function handleClick() {
-    setOpen(!open);
-  }
-
   return <div>
     <ListItem button
       key={expandableKey}
       className={expandableClassName}
       onClick={() => {
         expandableOnClick();
-        handleClick();
+        setOpen(!open);
       }}
     >
       <ListItemText
@@ -45,7 +41,7 @@ const ExpandableListItem: React.FC<{
     <Collapse in={open} timeout="auto" unmountOnExit>
       <List component="div" disablePadding>
         {(field.children as any[]).map((subfield, subfieldIndex) => !subfield ? undefined : (
-          <div><ListItem button
+          <ListItem button
              key={`${expandableKey}-${subfieldIndex}`}
              className={nestedClassName}
           >
@@ -53,7 +49,7 @@ const ExpandableListItem: React.FC<{
               primary={subfield.value ? subfield.value : '(empty)'}
               secondary={subfield.definition && subfield.definition.description ? subfield.definition.description : subfield.name}
             />
-          </ListItem></div>
+          </ListItem>
         ))}
       </List>
     </Collapse>

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -1,8 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { RouteComponentProps } from 'react-router';
 
-import { Typography, makeStyles, TextField, List, ListSubheader, ListItem, ListItemText, ListItemIcon, Collapse } from '@material-ui/core';
-import { ExpandMore, ExpandLess } from '@material-ui/icons';
+import { Typography, makeStyles, TextField, List, ListSubheader, ListItem, ListItemText } from '@material-ui/core';
 import ExpandableListItem from '../components/ExpandableListItem';
 
 import { inject, observer } from 'mobx-react';
@@ -164,7 +163,8 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                 </ListSubheader>
                 {(segment.children as any[]).map((field, fieldIndex) => !field ? undefined : (
                   <div>
-                    {field.children ? <div>
+                    {field.children ? (
+                      <div>
                       <ExpandableListItem
                         field={field}
                         expandableKey={`parsedField-${segmentIndex}-${fieldIndex}`}
@@ -173,7 +173,9 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                         nestedClassName={[classes.nested, selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field].join(' ')}
                       >
                       </ExpandableListItem>
-                    </div> : <ListItem
+                      </div>
+                    ) : (
+                      <ListItem
                         key={`parsedField-${segmentIndex}-${fieldIndex}`}
                         className={selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field}
                         onClick={() => setSelected([segmentIndex, fieldIndex])}
@@ -183,7 +185,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                             secondary={field.definition && field.definition.description ? field.definition.description : field.name}
                         />
                       </ListItem>
-                    }
+                    )}
                   </div>
                 ))}
               </ul>

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -3,6 +3,7 @@ import { RouteComponentProps } from 'react-router';
 
 import { Typography, makeStyles, TextField, List, ListSubheader, ListItem, ListItemText, ListItemIcon, Collapse } from '@material-ui/core';
 import { ExpandMore, ExpandLess } from '@material-ui/icons';
+import ExpandableListItem from '../components/ExpandableListItem';
 
 import { inject, observer } from 'mobx-react';
 import { FILE_STORE, IFileStore } from '../stores/fileStore';
@@ -92,15 +93,10 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
   const { messageIndex, fileId } = params as any
 
   const classes = useStyles();
-  const [open, setOpen] = React.useState(false);
   const [[selectedSegmentIndex, selectedFieldIndex], setSelected] = useState([-1, -1]);
   useEffect(() => {
     getMessage(fileId, parseInt(messageIndex))
   }, [getMessage, fileId, messageIndex])
-
-  function handleClick() {
-    setOpen(!open);
-  }
 
   const file = files.find((f) => f.id === fileId);
   const fileName = file ? file.name : 'Unknown File Name';
@@ -169,36 +165,14 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                 {(segment.children as any[]).map((field, fieldIndex) => !field ? undefined : (
                   <div>
                     {field.children ? <div>
-                      <ListItem button
-                        key={`parsedField-${segmentIndex}-${fieldIndex}`}
-                        className={selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field}
-                        onClick={() => {
-                          setSelected([segmentIndex, fieldIndex]);
-                          handleClick();
-                        }}
+                      <ExpandableListItem
+                        field={field}
+                        expandableKey={`parsedField-${segmentIndex}-${fieldIndex}`}
+                        expandableClassName={selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field}
+                        expandableOnClick={() => setSelected([segmentIndex, fieldIndex])}
+                        nestedClassName={[classes.nested, selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field].join(' ')}
                       >
-                        <ListItemText
-                            primary={field.value ? field.value : '(empty)'}
-                            secondary={field.definition && field.definition.description ? field.definition.description : field.name}
-                        />
-                        {open ? <ListItemIcon><ExpandLess/></ListItemIcon> : <ListItemIcon><ExpandMore/></ListItemIcon>}
-                      </ListItem>
-                      <Collapse in={open} timeout="auto" unmountOnExit>
-                        <List component="div" disablePadding>
-                          {(field.children as any[]).map((subfield, subfieldIndex) => !subfield ? undefined : (
-                            <div><ListItem button
-                              key={`parsedField-${segmentIndex}-${subfieldIndex}`}
-                              className={[classes.nested, selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field].join(' ')}
-                              onClick={() => setSelected([segmentIndex, subfieldIndex])}
-                            >
-                              <ListItemText
-                                primary={subfield.value ? subfield.value : '(empty)'}
-                                secondary={subfield.definition && subfield.definition.description ? subfield.definition.description : subfield.name}
-                              />
-                            </ListItem></div>
-                          ))}
-                        </List>
-                      </Collapse>
+                      </ExpandableListItem>
                     </div> : <ListItem
                         key={`parsedField-${segmentIndex}-${fieldIndex}`}
                         className={selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field}


### PR DESCRIPTION
### Related JIRA tickets:
- https://jira.amida.com/browse/HL7-35

### What exactly does this PR do?
- Adds ability to expand list items with subfields
  - New 'ExpandableListItem' component is used for every field that has children (instead of the plan ListItem component) 
  - ExpandableListItem includes an arrow symbol indicating the field can be expanded (which flips to point up/down depending on whether the field is currently expanded) and expands subfields on click

### What else was added outside of the scope of the ask?
- none

### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
- no

### Manual test cases?
- Run `yarn start` in this branch, navigate to `http://localhost:3000/auth/login` and login (if already logged in, go to `http://localhost:3000/app/files`)
- Click `Explore` on a file
- Scroll down the list of fields and see that some have chevron arrows pointing downwards on the right
- Confirm that the ones with arrows are the segments that have at least one `^` character
- Click on a field that can be expanded and confirm that its subfields appear in a sublist below it
- Click on the field again to collapse them

### Any additional context/background?
- N/A

### Screenshots (if appropriate):
