### PR TITLE
Feature/replace with hl7 dict

### DIFF
--- a/src/components/ExpandableListItem.tsx
+++ b/src/components/ExpandableListItem.tsx
@@ -4,10 +4,12 @@ import {ListItem, ListItemText, ListItemIcon, Collapse, List} from '@material-ui
 import { ExpandMore, ExpandLess } from '@material-ui/icons';
 
 import { Field } from 'health-level-seven-parser';
-var HL7Dictionary = require('hl7-dictionary');
+var HL7Dictionary = require('hl7-dictionary').definitions['2.7'];
 
 const ExpandableListItem: React.FC<{
   field: Field;
+  fieldIndex: number;
+  segmentName: string;
   expandableKey: string;
   expandableClassName: string;
   expandableOnClick: () => void;
@@ -18,12 +20,14 @@ const ExpandableListItem: React.FC<{
 
   const {
     field,
+    fieldIndex,
+    segmentName,
     expandableKey,
     expandableClassName,
     expandableOnClick,
     nestedClassName,
   } = props;
-
+  console.log('segment:', segmentName)
   return <div>
     <ListItem button
       key={expandableKey}
@@ -48,7 +52,11 @@ const ExpandableListItem: React.FC<{
           >
             <ListItemText
               primary={subfield.value ? subfield.value : '(empty)'}
-              secondary={HL7Dictionary.definitions['2.7'].segments[field.name.split('-')[0]].fields[field.name.split('-')[1]].desc ? HL7Dictionary.definitions['2.7'].segments[field.name.split('-')[0]].fields[field.name.split('-')[1]].desc : field.name}
+              // datatype={...HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype}
+              // {...console.log(field.name, field.value, HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype, fieldIndex, subfield.name, subfieldIndex)}
+              // {...console.log("lets see", HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex])}
+              // {...console.log('*****', HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields.desc == 'Extended Address' ? 'HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex].desc' : 'subfield.name')}
+              secondary={HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex] ? HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex].desc : subfield.name}
               // secondary={subfield.definition && subfield.definition.description ? subfield.definition.description : subfield.name}
             />
           </ListItem>

--- a/src/components/ExpandableListItem.tsx
+++ b/src/components/ExpandableListItem.tsx
@@ -4,6 +4,7 @@ import {ListItem, ListItemText, ListItemIcon, Collapse, List} from '@material-ui
 import { ExpandMore, ExpandLess } from '@material-ui/icons';
 
 import { Field } from 'health-level-seven-parser';
+var HL7Dictionary = require('hl7-dictionary');
 
 const ExpandableListItem: React.FC<{
   field: Field;
@@ -47,7 +48,8 @@ const ExpandableListItem: React.FC<{
           >
             <ListItemText
               primary={subfield.value ? subfield.value : '(empty)'}
-              secondary={subfield.definition && subfield.definition.description ? subfield.definition.description : subfield.name}
+              secondary={HL7Dictionary.definitions['2.7'].segments[field.name.split('-')[0]].fields[field.name.split('-')[1]].desc ? HL7Dictionary.definitions['2.7'].segments[field.name.split('-')[0]].fields[field.name.split('-')[1]].desc : field.name}
+              // secondary={subfield.definition && subfield.definition.description ? subfield.definition.description : subfield.name}
             />
           </ListItem>
         ))}

--- a/src/components/ExpandableListItem.tsx
+++ b/src/components/ExpandableListItem.tsx
@@ -4,7 +4,7 @@ import {ListItem, ListItemText, ListItemIcon, Collapse, List} from '@material-ui
 import { ExpandMore, ExpandLess } from '@material-ui/icons';
 
 import { Field } from 'health-level-seven-parser';
-var HL7Dictionary = require('hl7-dictionary').definitions['2.7'];
+const HL7Dictionary = require('hl7-dictionary').definitions['2.7.1'];
 
 const ExpandableListItem: React.FC<{
   field: Field;
@@ -39,7 +39,9 @@ const ExpandableListItem: React.FC<{
     >
       <ListItemText
         primary={field.value ? field.value : '(empty)'}
-        secondary={field.definition && field.definition.description ? field.definition.description : field.name}
+        secondary={
+          segmentName === 'MSH' ? HL7Dictionary.segments[segmentName].fields[fieldIndex].desc ? HL7Dictionary.segments[segmentName].fields[fieldIndex].desc : field.name :
+          HL7Dictionary.segments[segmentName].fields[fieldIndex-1].desc ? HL7Dictionary.segments[segmentName].fields[fieldIndex-1].desc : field.name}
       />
       {open ? <ListItemIcon><ExpandLess/></ListItemIcon> : <ListItemIcon><ExpandMore/></ListItemIcon>}
     </ListItem>
@@ -52,12 +54,12 @@ const ExpandableListItem: React.FC<{
           >
             <ListItemText
               primary={subfield.value ? subfield.value : '(empty)'}
-              // datatype={...HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype}
-              // {...console.log(field.name, field.value, HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype, fieldIndex, subfield.name, subfieldIndex)}
-              // {...console.log("lets see", HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex])}
-              // {...console.log('*****', HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields.desc == 'Extended Address' ? 'HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex].desc' : 'subfield.name')}
-              secondary={HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex] ? HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex].desc : subfield.name}
-              // secondary={subfield.definition && subfield.definition.description ? subfield.definition.description : subfield.name}
+              secondary={
+                segmentName === 'MSH' ? HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex] ? 
+                HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex].desc : subfield.name : 
+                HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex - 1].datatype].subfields[subfieldIndex] ? 
+                HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex-1].datatype].subfields[subfieldIndex].desc : 
+                HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex-1].datatype].desc}
             />
           </ListItem>
         ))}

--- a/src/components/ExpandableListItem.tsx
+++ b/src/components/ExpandableListItem.tsx
@@ -27,7 +27,6 @@ const ExpandableListItem: React.FC<{
     expandableOnClick,
     nestedClassName,
   } = props;
-  console.log('segment:', segmentName)
   return <div>
     <ListItem button
       key={expandableKey}

--- a/src/components/ExpandableListItem.tsx
+++ b/src/components/ExpandableListItem.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import {ListItem, ListItemText, ListItemIcon, Collapse, List} from '@material-ui/core';
 import { ExpandMore, ExpandLess } from '@material-ui/icons';
-
+import { HL7_DICT_OFFSET } from '../stores/userStore';
 import { Field } from 'health-level-seven-parser';
 const HL7Dictionary = require('hl7-dictionary').definitions['2.7.1'];
 
@@ -35,12 +35,13 @@ const ExpandableListItem: React.FC<{
         expandableOnClick();
         setOpen(!open);
       }}
+      /* ***hl7-dictionary library has it's segment field names offset off by one*** */
     >
       <ListItemText
         primary={field.value ? field.value : '(empty)'}
         secondary={
           segmentName === 'MSH' ? HL7Dictionary.segments[segmentName].fields[fieldIndex].desc ? HL7Dictionary.segments[segmentName].fields[fieldIndex].desc : field.name :
-          HL7Dictionary.segments[segmentName].fields[fieldIndex-1].desc ? HL7Dictionary.segments[segmentName].fields[fieldIndex-1].desc : field.name}
+          HL7Dictionary.segments[segmentName].fields[fieldIndex-HL7_DICT_OFFSET].desc ? HL7Dictionary.segments[segmentName].fields[fieldIndex-HL7_DICT_OFFSET].desc : field.name}
       />
       {open ? <ListItemIcon><ExpandLess/></ListItemIcon> : <ListItemIcon><ExpandMore/></ListItemIcon>}
     </ListItem>
@@ -56,9 +57,9 @@ const ExpandableListItem: React.FC<{
               secondary={
                 segmentName === 'MSH' ? HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex] ? 
                 HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex].datatype].subfields[subfieldIndex].desc : subfield.name : 
-                HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex - 1].datatype].subfields[subfieldIndex] ? 
-                HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex-1].datatype].subfields[subfieldIndex].desc : 
-                HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex-1].datatype].desc}
+                HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex - HL7_DICT_OFFSET].datatype].subfields[subfieldIndex] ? 
+                HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex-HL7_DICT_OFFSET].datatype].subfields[subfieldIndex].desc : 
+                HL7Dictionary.fields[HL7Dictionary.segments[segmentName].fields[fieldIndex-HL7_DICT_OFFSET].datatype].desc}
             />
           </ListItem>
         ))}

--- a/src/stores/userStore.ts
+++ b/src/stores/userStore.ts
@@ -59,3 +59,4 @@ export class UserStore implements IUserStore {
 }
 
 export const USER_STORE = 'userStore';
+export const HL7_DICT_OFFSET = 1

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -6,6 +6,7 @@ import ExpandableListItem from '../components/ExpandableListItem';
 
 import { inject, observer } from 'mobx-react';
 import { FILE_STORE, IFileStore } from '../stores/fileStore';
+import { HL7_DICT_OFFSET } from '../stores/userStore';
 const HL7DictionarySegments = require('hl7-dictionary').definitions['2.7.1'].segments;
 
 const useStyles = makeStyles(theme => ({
@@ -165,6 +166,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                 >
                   {HL7DictionarySegments[segment.name].desc ? HL7DictionarySegments[segment.name].desc  : segment.name}
                 </ListSubheader>
+                {/* ***hl7-dictionary library has it's segment field names offset off by one*** */}
                 {(segment.children as any[]).map((field, fieldIndex) => !field || fieldIndex === 0 ? undefined : (
                   <div key={fieldIndex}>
                     {field.children ? (
@@ -190,7 +192,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                             primary={field.value ? field.value : '(empty)'}
                             secondary={
                               segment.name === 'MSH' ? HL7DictionarySegments[segment.name].fields[fieldIndex].desc ? HL7DictionarySegments[segment.name].fields[fieldIndex].desc : field.name :
-                              HL7DictionarySegments[segment.name].fields[fieldIndex-1].desc ? HL7DictionarySegments[segment.name].fields[fieldIndex-1].desc : field.name}
+                              HL7DictionarySegments[segment.name].fields[fieldIndex-HL7_DICT_OFFSET].desc ? HL7DictionarySegments[segment.name].fields[fieldIndex-HL7_DICT_OFFSET].desc : field.name}
                         />
                       </ListItem>
                     )}

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -6,8 +6,7 @@ import ExpandableListItem from '../components/ExpandableListItem';
 
 import { inject, observer } from 'mobx-react';
 import { FILE_STORE, IFileStore } from '../stores/fileStore';
-var HL7DictionarySegments = require('hl7-dictionary').definitions['2.7'].segments;
-console.log(require('hl7-dictionary').definitions['2.7'])
+const HL7DictionarySegments = require('hl7-dictionary').definitions['2.7.1'].segments;
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -165,10 +164,9 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                   className={classes.listSectionListHeader}
                 >
                   {HL7DictionarySegments[segment.name].desc ? HL7DictionarySegments[segment.name].desc  : segment.name}
-                  {/* {segment.definition && segment.definition.description ? segment.definition.description : segment.name} */}
                 </ListSubheader>
-                {(segment.children as any[]).map((field, fieldIndex) => !field ? undefined : (
-                  <div>
+                {(segment.children as any[]).map((field, fieldIndex) => !field || fieldIndex === 0 ? undefined : (
+                  <div key={fieldIndex}>
                     {field.children ? (
                       <div>
                       <ExpandableListItem
@@ -178,8 +176,6 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                         expandableKey={`parsedField-${segmentIndex}-${fieldIndex}`}
                         expandableClassName={selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field}
                         expandableOnClick={() => setSelected([segmentIndex, fieldIndex])}
-                        {...console.log('if children',fieldIndex, field.name, field.definition && field.definition.description ? field.definition.description : field.name)}
-                        // {...console.log('fieldindex', field.children,fieldIndex, field.name, field.definition && field.definition.description ? field.definition.description : field.name)}
                         nestedClassName={[classes.nested, selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field].join(' ')}
                       >
                       </ExpandableListItem>
@@ -191,11 +187,10 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                         onClick={() => setSelected([segmentIndex, fieldIndex])}
                       >
                         <ListItemText
-                            {...console.log('if no children',fieldIndex, field.name, field.definition && field.definition.description ? field.definition.description : field.name)}
                             primary={field.value ? field.value : '(empty)'}
-                            // {...console.log('----->', fieldIndex, HL7DictionarySegments[segment.name].fields[fieldIndex].desc ? HL7DictionarySegments[segment.name].fields[fieldIndex].desc : field.name)}
-                            secondary={HL7DictionarySegments[segment.name].fields[fieldIndex].desc ? HL7DictionarySegments[segment.name].fields[fieldIndex].desc : field.name}
-                            // secondary={field.definition && field.definition.description ? field.definition.description : field.name} //this line you change
+                            secondary={
+                              segment.name === 'MSH' ? HL7DictionarySegments[segment.name].fields[fieldIndex].desc ? HL7DictionarySegments[segment.name].fields[fieldIndex].desc : field.name :
+                              HL7DictionarySegments[segment.name].fields[fieldIndex-1].desc ? HL7DictionarySegments[segment.name].fields[fieldIndex-1].desc : field.name}
                         />
                       </ListItem>
                     )}

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -6,8 +6,8 @@ import ExpandableListItem from '../components/ExpandableListItem';
 
 import { inject, observer } from 'mobx-react';
 import { FILE_STORE, IFileStore } from '../stores/fileStore';
-var HL7Dictionary = require('hl7-dictionary');
-console.log(HL7Dictionary.definitions['2.7'])
+var HL7DictionarySegments = require('hl7-dictionary').definitions['2.7'].segments;
+console.log(require('hl7-dictionary').definitions['2.7'])
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -103,6 +103,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
 
   const filename = (currentFile && currentFile.filename) || 'Unknown File';
   const message = currentMessage;
+  const index = 0
   
   return message ? (
     <div className={classes.container}>
@@ -171,9 +172,13 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                       <div>
                       <ExpandableListItem
                         field={field}
+                        fieldIndex={fieldIndex}
+                        segmentName={segment.name}
                         expandableKey={`parsedField-${segmentIndex}-${fieldIndex}`}
                         expandableClassName={selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field}
                         expandableOnClick={() => setSelected([segmentIndex, fieldIndex])}
+                        {...console.log('if children',fieldIndex, field.name, field.definition && field.definition.description ? field.definition.description : field.name)}
+                        // {...console.log('fieldindex', field.children,fieldIndex, field.name, field.definition && field.definition.description ? field.definition.description : field.name)}
                         nestedClassName={[classes.nested, selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field].join(' ')}
                       >
                       </ExpandableListItem>
@@ -185,9 +190,10 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                         onClick={() => setSelected([segmentIndex, fieldIndex])}
                       >
                         <ListItemText
+                            {...console.log('if no children',fieldIndex, field.name, field.definition && field.definition.description ? field.definition.description : field.name)}
                             primary={field.value ? field.value : '(empty)'}
-                            {...console.log('inside div', HL7Dictionary.definitions['2.7'].segments[field.name.split('-')[0]].fields[field.name.split('-')[1]].desc)}
-                            secondary={HL7Dictionary.definitions['2.7'].segments[field.name.split('-')[0]].fields[field.name.split('-')[1]].desc ? HL7Dictionary.definitions['2.7'].segments[field.name.split('-')[0]].fields[field.name.split('-')[1]].desc : field.name}
+                            // {...console.log('----->', fieldIndex, HL7DictionarySegments[segment.name].fields[fieldIndex].desc ? HL7DictionarySegments[segment.name].fields[fieldIndex].desc : field.name)}
+                            secondary={HL7DictionarySegments[segment.name].fields[fieldIndex].desc ? HL7DictionarySegments[segment.name].fields[fieldIndex].desc : field.name}
                             // secondary={field.definition && field.definition.description ? field.definition.description : field.name} //this line you change
                         />
                       </ListItem>

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -6,6 +6,8 @@ import ExpandableListItem from '../components/ExpandableListItem';
 
 import { inject, observer } from 'mobx-react';
 import { FILE_STORE, IFileStore } from '../stores/fileStore';
+var HL7Dictionary = require('hl7-dictionary');
+console.log(HL7Dictionary.definitions['2.7'])
 
 const useStyles = makeStyles(theme => ({
   container: {
@@ -101,6 +103,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
 
   const filename = (currentFile && currentFile.filename) || 'Unknown File';
   const message = currentMessage;
+  
   return message ? (
     <div className={classes.container}>
       <Typography
@@ -183,7 +186,9 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                       >
                         <ListItemText
                             primary={field.value ? field.value : '(empty)'}
-                            secondary={field.definition && field.definition.description ? field.definition.description : field.name}
+                            {...console.log('inside div', HL7Dictionary.definitions['2.7'].segments[field.name.split('-')[0]].fields[field.name.split('-')[1]].desc)}
+                            secondary={HL7Dictionary.definitions['2.7'].segments[field.name.split('-')[0]].fields[field.name.split('-')[1]].desc ? HL7Dictionary.definitions['2.7'].segments[field.name.split('-')[0]].fields[field.name.split('-')[1]].desc : field.name}
+                            // secondary={field.definition && field.definition.description ? field.definition.description : field.name} //this line you change
                         />
                       </ListItem>
                     )}

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -164,7 +164,8 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                 <ListSubheader
                   className={classes.listSectionListHeader}
                 >
-                  {segment.definition && segment.definition.description ? segment.definition.description : segment.name}
+                  {HL7DictionarySegments[segment.name].desc ? HL7DictionarySegments[segment.name].desc  : segment.name}
+                  {/* {segment.definition && segment.definition.description ? segment.definition.description : segment.name} */}
                 </ListSubheader>
                 {(segment.children as any[]).map((field, fieldIndex) => !field ? undefined : (
                   <div>


### PR DESCRIPTION
### Related JIRA tickets:
-https://jira.amida.com/browse/HL7-36

### What exactly does this PR do?
- Some message/field types were not getting description fields from our parser. This pr looks these up in hl7-dictionary and display the relevant info.

### What else was added outside of the scope of the ask?
- Displaying the description of each of the segments as the header for each of the segments in the list instead of just the segment name ie. instead of displaying MSH, PID, PV1 etc. we now display "Message Header", "Patient Identification", "Patient Visit", etc. respectively.

### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
- I don't think so.

### Manual test cases?
- Checkout `develop` and notice that some of the message/fields description (specially in the RXO section) are empty and display the field name ie. RXO-1, RXO2, etc.
- Checkout `feature/replace-with-hl7-dict` and notice that most if not all of the message/fields descriptions (specially in the RXO section) are now  being displayed.


### Any additional context/background?
- See attached screenshots

### Screenshots (if appropriate):
- In `develop`

<img width="1498" alt="Screen Shot 2019-09-12 at 11 34 06 PM" src="https://user-images.githubusercontent.com/39383117/64836909-05d52980-d5ba-11e9-966c-81c0d44cf58a.png">

- In `feature/replace-with-hl7-dict`

<img width="1501" alt="Screen Shot 2019-09-12 at 11 35 09 PM" src="https://user-images.githubusercontent.com/39383117/64836913-0968b080-d5ba-11e9-8a86-501e288ab7f0.png">