### PR TITLE
Feature/hl7-41-42

### DIFF
--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -14,7 +14,6 @@ api.interceptors.response.use(function (response) {
 }, function (error) {
   if (error.response.status === 401) {
     stores[USER_STORE].logout();
-    alert("Oops! Your session has expired. Please sign in to continue");
   }
   return error;
 });

--- a/src/views/LoginPage.tsx
+++ b/src/views/LoginPage.tsx
@@ -17,6 +17,9 @@ const useStyles = makeStyles(theme => ({
   button: {
     margin: theme.spacing(4, 0, 0, 0),
   },
+  errorText: {
+    color: 'red'
+  },
 }));
 
 const LoginPageImpl: React.FC<RouteComponentProps & { userStore: IUserStore }> = (props) => {
@@ -37,6 +40,12 @@ const LoginPageImpl: React.FC<RouteComponentProps & { userStore: IUserStore }> =
       setError(true);
     }
   };
+
+  const handleKeyPress = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if(event.key === 'Enter'){
+      signUpAction()
+    }
+  }
 
   return (
     <Container maxWidth="sm">
@@ -59,6 +68,7 @@ const LoginPageImpl: React.FC<RouteComponentProps & { userStore: IUserStore }> =
               label="Username"
               value={username}
               onChange={(event) => setUsername(event.target.value)}
+              onKeyDown={(event) =>  handleKeyPress(event)}
             />
           </Grid>
           <Grid item>
@@ -67,6 +77,7 @@ const LoginPageImpl: React.FC<RouteComponentProps & { userStore: IUserStore }> =
               type="password"
               value={password}
               onChange={(event) => setPassword(event.target.value)}
+              onKeyDown={(event) =>  handleKeyPress(event)}
             />
           </Grid>
         </Grid>
@@ -78,7 +89,7 @@ const LoginPageImpl: React.FC<RouteComponentProps & { userStore: IUserStore }> =
           sign in
         </Button>
         { error && (
-          <Typography variant="body1">
+          <Typography variant="body1" className={classes.errorText}>
             Invalid Username or Password. Please Try Again.
           </Typography>
         )}

--- a/src/views/LoginPage.tsx
+++ b/src/views/LoginPage.tsx
@@ -79,7 +79,7 @@ const LoginPageImpl: React.FC<RouteComponentProps & { userStore: IUserStore }> =
         </Button>
         { error && (
           <Typography variant="body1">
-            Error. Try Again.
+            Invalid Username or Password. Please Try Again.
           </Typography>
         )}
         <Link to="/auth/signup">Register here</Link>

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -44,6 +44,7 @@ const useStyles = makeStyles(theme => ({
     fontSize: '1.2em',
     lineHeight: '1.3em',
     whiteSpace: 'nowrap',
+    cursor:'default'
   },
   segmentListContainer: {
     gridArea: 'list',
@@ -74,6 +75,7 @@ const useStyles = makeStyles(theme => ({
   },
   selectedField: {
     backgroundColor: 'lightgreen',
+    cursor:'default',
   },
   field: {
     '&:hover': {


### PR DESCRIPTION
### Related JIRA tickets:
>Please enter the whole URL so we can just click/copy it
- https://jira.amida.com/browse/HL7-41
- https://jira.amida.com/browse/HL7-42
- https://jira.amida.com/browse/HL7-39

### What exactly does this PR do?
>i.e. Added logic to do the thing because the thing didn't exist before. Please provide as much detail as possible. 
- This PR does two things. It removes the pop up alert that was being triggered whenever the client would get a `401` response. Usually when there was an invalid attempt to log in or if the session expired. Now, when there is an invalid attempt for signing in, an error is displayed. When the session expires, the user is just navigated back to the log in page with out a pop up alert. The other thing that this PR does is that when a user is signing in, pressing the `Enter` key in the keyboard whenever the `username` or `password` are focused, the same function that the `sign in` button calls is called. This means that you can type in your username and then after finishing typing your password, you can press `Enter` and you will be signed in.

- This PR also sets the cursor to `default` for the `selectedField` and the `rawMessageContainer` style classes. Now, all non-editable text gets a default cursor.

### What else was added outside of the scope of the ask?
>i.e. Simple bugfix, corrected typos, cleaned up code, etc
- I made colored red the error produced whenever there is an invalid attempt to log in

### Do ANY of these changes introduce a breaking change? (in-scope or otherwise)
>i.e. Users need to update their `.env` files with the following... etc
- No.

### Manual test cases?
>Steps to manually test introduced changes can go here.
>Remember the prerequisites!
>Remember edge-cases you've caught in your code, etc..
> i.e. ignoring the button and clicking on the "NEXT" button should trigger a warning event because the thing that clicking the new button does didn't happen
- Checkout this branch
- Run the client and the server

**Testing HL7-41**
- When you're in the signed in page, enter a wrong password or username and the click on the sign in button.
- A red error message is displayed instead of a pop alert that says `oopss! your session has expired`
- Now open up your server `.env` and set the `JWT_EXP_TIME` to `3s` instead of `1h` save it and run the server again.
- now in the client, log in with a valid credentials and wait 3 secs then refresh the page.
- you should be navigated back to the sign in page and no pop alert saying `oopss! your session has expired` should be displayed.

**Testing HL7-42**
- Navigate to the sign in page
- enter usename and press `enter` (or `return` if you have mac). An error you be displayed.
- Delete the username and then just enter your password and press `enter` (or `return` if you have mac) again. An error you be displayed.
- Enter your username and password and then press `enter` (or `return` if you have mac) again. you should be signed in

**Testing HL7-39**
- Navigate to the message page
- Ensure that the pipes (`|`) and list item text get a default cursor.
