### PR TITLE
prev and next navigation buttons

### DIFF
--- a/src/components/PreviousForwardButtons.tsx
+++ b/src/components/PreviousForwardButtons.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { Button } from '@material-ui/core'
+
+const PreviousForwardButtons: React.FC<{
+    onBack: (event: any) => void;
+    value: number;
+    onForward: (event: any) => void
+  }> = (props) => {
+    const {
+        onBack,
+        value,
+        onForward,
+      } = props;
+    
+      return <div>
+        <Button className='button' onClick={onBack}>
+          Prev
+        </Button>
+        {value}
+        <Button className='button' onClick={onForward}>
+          Next
+        </Button>
+
+      </div>
+  }
+  export default PreviousForwardButtons;

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { RouteComponentProps } from 'react-router';
 
 import { Typography, makeStyles, TextField, List, ListSubheader, ListItem, ListItemText } from '@material-ui/core';
 import ExpandableListItem from '../components/ExpandableListItem';
+import PreviousForwardButtons from '../components/PreviousForwardButtons'
 
 import { inject, observer } from 'mobx-react';
 import { FILE_STORE, IFileStore } from '../stores/fileStore';
@@ -101,6 +102,16 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
 
   const filename = (currentFile && currentFile.filename) || 'Unknown File';
   const message = currentMessage;
+
+  const messagePage = useCallback(
+    (i: number) => () =>{
+      var index = parseInt(messageIndex) + i
+      index = (index < 0 ? 0 : index)
+      history.push(`/app/files/${fileId}/messages/${index}`)
+    },
+    [history, fileId, messageIndex]
+  );
+
   return message ? (
     <div className={classes.container}>
       <Typography
@@ -114,13 +125,12 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
         placeholder="I.e. PID-5 = ERIC"
         label="Filter"
       />
-      <TextField
-        className={classes.messageSelector}
-        type="number"
+      <PreviousForwardButtons
+        onBack={messagePage(-1)}
         value={message.messageNumWithinFile}
-        label="Message Number"
-        onChange={(event) => history.push(`/app/files/${fileId}/messages/${event.target.value}`)}
-      />
+        onForward={messagePage(1)}
+      >
+      </PreviousForwardButtons>
       <div className={classes.rawMessageContainer}>
         {message.rawMessage.split('\n').filter(segment => !!segment).map((segment, segmentIndex) => (
           <div


### PR DESCRIPTION
### Related JIRA tickets:
>Please enter the whole URL so we can just click/copy it
- https://jira.amida.com/browse/HL7-30

### What exactly does this PR do?
>i.e. Added logic to do the thing because the thing didn't exist before. Please provide as much detail as possible. 
- It replace the message number input with a number and forward/back buttons in the top right hand side of the `Message Page`
- Refer to Jira Ticket for more details.

### Manual test cases?
- Checkout branch
- sign in and upload a hl7 message
- Click `explore`
- In the `Message Page` notice that there are two buttons an a number. The first button is to go back to the previous message and the 2nd button is to go to the next message. The number indicates the message number within the hl7 message file.
- Click both buttons and ensure that they work and that they navigate you to different messages.