### PR TITLE
Feature autoscroll to selected field list item

### DIFF
--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef, createRef, RefObject} from 'react';
+import React, { useState, useEffect } from 'react';
 import { RouteComponentProps } from 'react-router';
 
 import { Typography, makeStyles, TextField, List, ListSubheader, ListItem, ListItemText } from '@material-ui/core';

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -87,9 +87,6 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
-
-// const useMountEffect = (fun: { (): void; (): void | (() => void | undefined); }) => useEffect(fun, [])
-
 const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }> = (props) => {
   const { history, match: { params }, fileStore: { getMessage, currentMessage, getFile, currentFile } } = props;
   const { messageIndex, fileId } = params as any;
@@ -105,44 +102,14 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
   const filename = (currentFile && currentFile.filename) || 'Unknown File';
   const message = currentMessage;
 
-
-
-  // const itemRefs = useRef([{}].map(() => createRef<HTMLDivElement>()));
-  // const itemRefs = useRef([...Array(3)].map(() => createRef()));
-  // const itemRefs = createRef<HTMLDivElement[]>()
-
-  // const list: RefObject<RefObject<HTMLDivElement>>[] = []
-  // const refs = list.map((acc, index) => {
-  //   acc[index] = createRef<React.RefObject<HTMLDivElement>>();
-  //   return acc;
-  // }, {});
-
-  // const handleClick = (id: string | number) =>
-  //   refs[id].current.scrollIntoView({
-  //     behavior: 'smooth',
-  //     block: 'start',
-  //   });
-
-
-
-    
-
-  const myRef = createRef<HTMLDivElement>()
-  const scrollToRef = (ref: React.RefObject<HTMLDivElement>) => {
-    if(ref && ref.current)
-      ref.current.scrollIntoView({
-        behavior: 'smooth',
-        block: 'end'
-      });
-      // window.scrollTo({
-      //   top: ref.current.offsetTop,
-      //   behavior: 'smooth',
-      // });
-      // window.scrollTo(0, ref.current.offsetTop)
+  const jumpTo = (segmentIndex:number, fieldIndex:number) => {
+    let div = (document.getElementById(`${segmentIndex}-${fieldIndex}`)!) // as HTMLInputElement is also valid
+      div.scrollIntoView({
+          behavior: 'smooth',
+          block: 'center',
+          inline: 'center'
+        });
   }
-  // useMountEffect(() => scrollToRef(myRef)) // Scroll on mount
-
-
 
   return message ? (
     <div className={classes.container}>
@@ -177,7 +144,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                 {fieldIndex !== 0 && '|'}
                 <span
                   className={selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field}
-                  onClick={() => {setSelected([segmentIndex, fieldIndex]); scrollToRef(myRef)}}
+                  onClick={() => {setSelected([segmentIndex, fieldIndex]); jumpTo(segmentIndex, fieldIndex);}}
                 >
                   {field}
                 </span>
@@ -206,8 +173,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                   {segment.definition && segment.definition.description ? segment.definition.description : segment.name}
                 </ListSubheader>
                 {(segment.children as any[]).map((field, fieldIndex) => !field ? undefined : (
-                  // <div ref={el => (refs && refs.current ? refs.current[fieldIndex] = el : undefined)} key={fieldIndex}>
-                  <div ref={myRef}>
+                  <div id={`${segmentIndex}-${fieldIndex}`} key={`${segmentIndex}-${fieldIndex}`}>
                     {field.children ? (
                       <div>
                       <ExpandableListItem

--- a/src/views/MessagePage.tsx
+++ b/src/views/MessagePage.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef, createRef, RefObject} from 'react';
 import { RouteComponentProps } from 'react-router';
 
 import { Typography, makeStyles, TextField, List, ListSubheader, ListItem, ListItemText } from '@material-ui/core';
@@ -87,6 +87,9 @@ const useStyles = makeStyles(theme => ({
   },
 }));
 
+
+// const useMountEffect = (fun: { (): void; (): void | (() => void | undefined); }) => useEffect(fun, [])
+
 const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }> = (props) => {
   const { history, match: { params }, fileStore: { getMessage, currentMessage, getFile, currentFile } } = props;
   const { messageIndex, fileId } = params as any;
@@ -101,6 +104,46 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
 
   const filename = (currentFile && currentFile.filename) || 'Unknown File';
   const message = currentMessage;
+
+
+
+  // const itemRefs = useRef([{}].map(() => createRef<HTMLDivElement>()));
+  // const itemRefs = useRef([...Array(3)].map(() => createRef()));
+  // const itemRefs = createRef<HTMLDivElement[]>()
+
+  // const list: RefObject<RefObject<HTMLDivElement>>[] = []
+  // const refs = list.map((acc, index) => {
+  //   acc[index] = createRef<React.RefObject<HTMLDivElement>>();
+  //   return acc;
+  // }, {});
+
+  // const handleClick = (id: string | number) =>
+  //   refs[id].current.scrollIntoView({
+  //     behavior: 'smooth',
+  //     block: 'start',
+  //   });
+
+
+
+    
+
+  const myRef = createRef<HTMLDivElement>()
+  const scrollToRef = (ref: React.RefObject<HTMLDivElement>) => {
+    if(ref && ref.current)
+      ref.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end'
+      });
+      // window.scrollTo({
+      //   top: ref.current.offsetTop,
+      //   behavior: 'smooth',
+      // });
+      // window.scrollTo(0, ref.current.offsetTop)
+  }
+  // useMountEffect(() => scrollToRef(myRef)) // Scroll on mount
+
+
+
   return message ? (
     <div className={classes.container}>
       <Typography
@@ -134,7 +177,7 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                 {fieldIndex !== 0 && '|'}
                 <span
                   className={selectedSegmentIndex === segmentIndex && selectedFieldIndex === fieldIndex ? classes.selectedField : classes.field}
-                  onClick={() => setSelected([segmentIndex, fieldIndex])}
+                  onClick={() => {setSelected([segmentIndex, fieldIndex]); scrollToRef(myRef)}}
                 >
                   {field}
                 </span>
@@ -163,7 +206,8 @@ const MessagePageImpl: React.FC<RouteComponentProps & { fileStore: IFileStore }>
                   {segment.definition && segment.definition.description ? segment.definition.description : segment.name}
                 </ListSubheader>
                 {(segment.children as any[]).map((field, fieldIndex) => !field ? undefined : (
-                  <div>
+                  // <div ref={el => (refs && refs.current ? refs.current[fieldIndex] = el : undefined)} key={fieldIndex}>
+                  <div ref={myRef}>
                     {field.children ? (
                       <div>
                       <ExpandableListItem


### PR DESCRIPTION
### Related JIRA tickets:
>Please enter the whole URL so we can just click/copy it
- https://jira.amida.com/browse/HL7-34

### What exactly does this PR do?
>i.e. Added logic to do the thing because the thing didn't exist before. Please provide as much detail as possible. 
- This PR create an ID for each divs corresponding to each field item in the parsed list. It uses that idea to refer to that div and scroll to it based on the user selection in the raw message section


### Manual test cases?
- Navigate to the `MessagePage`
- Click on any of the fields in the raw message on the left preferably in the lower part of the message.
- See how the parsed message list on the right scrolls to the field corresponding to the clicked  field in the raw message
